### PR TITLE
chore: corrige alertas apontados no OWASP ZAP

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3452,14 +3452,15 @@
             }
         },
         "node_modules/es5-ext": {
-            "version": "0.10.62",
-            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
-            "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
+            "version": "0.10.64",
+            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
+            "integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
             "dev": true,
             "hasInstallScript": true,
             "dependencies": {
                 "es6-iterator": "^2.0.3",
                 "es6-symbol": "^3.1.3",
+                "esniff": "^2.0.1",
                 "next-tick": "^1.1.0"
             },
             "engines": {
@@ -3679,6 +3680,27 @@
             "engines": {
                 "node": ">=4.0"
             }
+        },
+        "node_modules/esniff": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
+            "integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
+            "dev": true,
+            "dependencies": {
+                "d": "^1.0.1",
+                "es5-ext": "^0.10.62",
+                "event-emitter": "^0.3.5",
+                "type": "^2.7.2"
+            },
+            "engines": {
+                "node": ">=0.10"
+            }
+        },
+        "node_modules/esniff/node_modules/type": {
+            "version": "2.7.2",
+            "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
+            "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw==",
+            "dev": true
         },
         "node_modules/espree": {
             "version": "9.6.0",
@@ -4167,9 +4189,9 @@
             "dev": true
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.2",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-            "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+            "version": "1.15.5",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+            "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
             "funding": [
                 {
                     "type": "individual",
@@ -4559,9 +4581,9 @@
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
         "node_modules/ip": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
-            "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
+            "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ=="
         },
         "node_modules/ipaddr.js": {
             "version": "1.9.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,9 @@
                 "drizzle-orm": "^0.28.6",
                 "express": "^4.18.2",
                 "express-async-errors": "^3.1.1",
+                "helmet": "^7.1.0",
                 "mongoose": "^7.2.3",
+                "nocache": "^4.0.0",
                 "postgres": "^3.4.2",
                 "swagger-ui-express": "^4.6.3"
             },
@@ -4439,6 +4441,14 @@
             "integrity": "sha512-2bsegYkkHO+h/9MGbn6KWcE45cHZgPANo5LXF7EvWdT0yT2EguSVO1nDgU5c8+ZOPwp2vMNa7YFsJhVcDR9Sdg==",
             "dev": true
         },
+        "node_modules/helmet": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/helmet/-/helmet-7.1.0.tgz",
+            "integrity": "sha512-g+HZqgfbpXdCkme/Cd/mZkV0aV3BZZZSugecH03kl38m/Kmdx8jKjBikpDj2cr+Iynv4KpYEviojNdTJActJAg==",
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
         "node_modules/html-escaper": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -5821,6 +5831,14 @@
             "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
             "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
             "dev": true
+        },
+        "node_modules/nocache": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/nocache/-/nocache-4.0.0.tgz",
+            "integrity": "sha512-AntnTbmKZvNYIsTVPPwv7dfZdAfo/6H/2ZlZACK66NAOQtIApxkB/6pf/c+s+ACW8vemGJzUCyVTssrzNUK6yQ==",
+            "engines": {
+                "node": ">=16.0.0"
+            }
         },
         "node_modules/node-int64": {
             "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,9 @@
         "drizzle-orm": "^0.28.6",
         "express": "^4.18.2",
         "express-async-errors": "^3.1.1",
+        "helmet": "^7.1.0",
         "mongoose": "^7.2.3",
+        "nocache": "^4.0.0",
         "postgres": "^3.4.2",
         "swagger-ui-express": "^4.6.3"
     },

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -1,14 +1,28 @@
 import express from "express";
+import helmet from "helmet";
+import nocache from "nocache";
 import { serve, setup } from "swagger-ui-express";
 import { errorHandler } from "./middlewares";
 import { makeServerRouter } from "./routes";
 import { requestLogger } from "../utils/requestLogger";
 import { SwaggerConfig } from "./docs";
+import { serverConfig } from "config";
 
 require("dotenv").config();
 
 function buildServer() {
     const server = express();
+
+    server.disable("x-powered-by");
+    server.use(helmet());
+    server.use(nocache());
+
+    if (serverConfig.isProduction) {
+        server.use(helmet.hsts({
+            maxAge: 31536000,
+            includeSubDomains: true
+        }));
+    }
 
     server.use(requestLogger);
 


### PR DESCRIPTION
- Desabilita "x-powered-by"
- Adiciona lib Helmet que tem os middlewares que o OWASP apontou 
   - sobre o helmet, teoricamente precisa configurar o helmet.hsts porém o GPT respondeu isso:
       _Lembre-se de que o uso do HSTS é recomendado apenas se você estiver servindo seu site exclusivamente via HTTPS. Se você 
       ainda suporta HTTP, não ative essa configuração, pois isso pode impedir que os usuários acessem seu site._ (coloquei na config apenas para quando está em produção que vai ser HTTPS)
       
- Adiciona lib nocache para configurar o header Cache-Control
- Corrige dependências apontadas como vulnerabildades no npm

links uteis: 
https://expressjs.com/en/advanced/best-practice-security.html
https://blog.logrocket.com/using-helmet-node-js-secure-application/
https://retz.dev/blog/setting-security-headers-for-web-app:-nginx-express-and-react.
https://cheatsheetseries.owasp.org/cheatsheets/Nodejs_Security_Cheat_Sheet.html